### PR TITLE
Update PhotoData.php

### DIFF
--- a/src/ondrs/Sauto/Structs/PhotoData.php
+++ b/src/ondrs/Sauto/Structs/PhotoData.php
@@ -14,7 +14,7 @@ class PhotoData extends BaseStruct
     public $main;
     public $alt;
     public $client_photo_id;
-    public $b64;
+    // public $b64;
 
 
     /**


### PR DESCRIPTION
$b64 attribute MUST be missing when updating the image with "addEditPhoto", otherwise it will fail with error.